### PR TITLE
Add a `CONTRIBUTING.md` file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,142 @@
+# Contributing to this project
+
+Anyone and everyone is welcome to contribute, but please take a moment to
+review this guidelines for contributing to make this process easy and effective
+for everyone.
+
+Following these guidelines helps to communicate that you respect the time of
+those developers managing and developing an open source project. In return,
+they should reciprocate that respect in addressing your issue and
+assessing patches and features.
+
+If you think this guide can be improved, please share your thoughts.
+
+
+## Using the issue tracker
+
+The issue tracker is the preferred channel for [reporting bugs](#reporting-bugs),
+[requesting features](#requesting-features) and
+[submitting pull requests](#submitting-pull-requests), but please respect the
+following restrictions:
+
+* Please **do not** use the issue tracker for personal support requests (use
+StackOverflow or IRC).
+
+* Please **do not** derail or troll issues. Keep the
+discussion on topic and respect the opinions of others.
+
+
+## Reporting bugs
+
+A bug is a _demonstrable problem_ that is caused by the code in the
+repository. Good bug reports are extremely helpful - thank you!
+
+### Guidelines for bug reports
+
+1. **Use the GitHub issue search** &mdash; check if the issue has already been
+   reported.
+
+2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
+   latest `master` or development branch in the repository.
+
+3. **Isolate the problem** &mdash; ideally create a [reduced test
+   case](http://css-tricks.com/6263-reduced-test-cases/) and a live example.
+
+A good bug report shouldn't leave others needing to chase you up for more
+information. Please try to be as detailed as possible in your report. What is
+your environment? What steps will reproduce the issue? What browser(s) and OS
+experience the problem? What would you expect to be the outcome? All these
+details will help people to fix any potential bugs, see this **example of a
+good bug report**:
+
+> Short and descriptive example bug report title
+>
+> A summary of the issue and the browser/OS environment in which it occurs. If
+> suitable, include the steps required to reproduce the bug.
+>
+> 1. This is the first step
+> 2. This is the second step
+> 3. Further steps, etc.
+>
+> `<url>` - a link to the reduced test case
+>
+> Any other information you want to share that is relevant to the issue being
+> reported. This might include the lines of code that you have identified as
+> causing the bug, and potential solutions (and your opinions on their
+> merits).
+
+
+## Requesting features
+
+Feature requests are welcome. But take a moment to find out whether your idea
+fits with the scope and aims of the project. It's up to *you* to make a strong
+case to convince the project's developers of the merits of this feature. Please
+provide as much detail and context as possible.
+
+### Enquiring about contributions
+
+Contribution enquiries should take place before any significant pull request
+(e.g. implementing features, refactoring code, porting to a different
+language), otherwise you risk spending a lot of time working on something that
+the project's developers might not want to pull into the repository.
+
+
+## Submitting pull requests
+
+Good pull requests - patches, improvements, new features - are a fantastic
+help. They should remain focused in scope and avoid containing unrelated
+commits.
+
+Make sure to adhere to the coding conventions used throughout a project
+(indentation, accurate comments, etc.) and any other requirements (such as test
+coverage).
+
+Please follow this process; it's the best way to get your work included in the
+project:
+
+1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
+   and configure the remotes:
+
+   ```bash
+   # Clones your fork of the repo into the current directory in terminal
+   git clone https://github.com/<your-username>/<repo-name>.git
+   # Navigate to the newly cloned directory
+   cd <repo-name>
+   # Assigns the original repo to a remote called "upstream"
+   git remote add upstream https://github.com/<upsteam-owner>/<repo-name>.git
+   ```
+
+2. If you cloned a while ago, get the latest changes from upstream:
+
+   ```bash
+   git checkout <dev-branch>
+   git pull upstream <dev-branch>
+   ```
+
+3. Create a new topic branch to contain your feature, change, or fix:
+
+   ```bash
+   git checkout -b <topic-branch-name>
+   ```
+
+4. Commit your changes in logical chunks. Please adhere to these [git commit
+   message
+   guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
+   or your pull request is unlikely be merged into the main project. Use git's
+   [interactive rebase](https://help.github.com/articles/interactive-rebase)
+   feature to tidy up your commits before making them public.
+
+5. Locally merge (or rebase) the upstream development branch into your topic branch:
+
+   ```bash
+   git pull [--rebase] upstream <dev-branch>
+   ```
+
+6. Push your topic branch up to your fork:
+
+   ```bash
+   git push origin <topic-branch-name>
+   ```
+
+10. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
+    with a clear title and description.

--- a/README.md
+++ b/README.md
@@ -1,132 +1,23 @@
-# Rules of engagement
+# Issue Guidelines
 
-Following these guidelines helps to communicate that you respect the time of
-those developers managing and developing an open source project. In return,
-they should reciprocate that respect in addressing your issue and
-assessing patches and features.
+This is a set of guidelines for submitting issues and pull requests on projects.
+
+The actual guidelines are presented in [CONTRIBUTING](CONTRIBUTING.md):
+* This ensures the README remains concise, readers are guided via the short section
+[Contributing to this project](#contributing-to-this-project) to more detailed information.
+* It also allows to take advantage of GitHub's smart usability feature that prompts
+people to read a repo's guidelines before reporting issues or opening pull requests,
+see [Contributing Guidelines](https://github.com/blog/1184-contributing-guidelines).
 
 If you think this guide can be improved, please share your thoughts.
 
 
-## Do not…
+## Contributing to this project
 
-Please **do not** use the issue tracker for personal support requests (use
-StackOverflow or IRC).
+Anyone and everyone is welcome to contribute, but please take a moment to
+review the [guidelines for contributing](CONTRIBUTING.md) to make this process
+easy and effective for everyone, in particular:
 
-Please **do not** derail or troll issues. Keep the
-discussion on topic and respect the opinions of others.
-
-
-## Bugs
-
-A bug is a _demonstrable problem_ that is caused by the code in the
-repository. Good bug reports are extremely helpful - thank you!
-
-Guidelines for bug reports:
-
-1. **Use the GitHub issue search** &mdash; check if the issue has already been
-   reported.
-
-2. **Check if the issue has been fixed** &mdash; try to reproduce it using the
-   latest `master` or development branch in the repository.
-
-3. **Isolate the problem** &mdash; ideally create a [reduced test
-   case](http://css-tricks.com/6263-reduced-test-cases/) and a live example.
-
-A good bug report shouldn't leave others needing to chase you up for more
-information. Please try to be as detailed as possible in your report. What is
-your environment? What steps will reproduce the issue? What browser(s) and OS
-experience the problem? What would you expect to be the outcome? All these
-details will help people to fix any potential bugs.
-
-Example:
-
-> Short and descriptive example bug report title
->
-> A summary of the issue and the browser/OS environment in which it occurs. If
-> suitable, include the steps required to reproduce the bug.
->
-> 1. This is the first step
-> 2. This is the second step
-> 3. Further steps, etc.
->
-> `<url>` - a link to the reduced test case
->
-> Any other information you want to share that is relevant to the issue being
-> reported. This might include the lines of code that you have identified as
-> causing the bug, and potential solutions (and your opinions on their
-> merits).
-
-
-## Feature requests & contribution enquiries
-
-Feature requests are welcome. But take a moment to find out whether your idea
-fits with the scope and aims of the project. It's up to *you* to make a strong
-case to convince the project's developers of the merits of this feature. Please
-provide as much detail and context as possible.
-
-Contribution enquiries should take place before any significant pull request
-(e.g. implementing features, refactoring code, porting to a different
-language), otherwise you risk spending a lot of time working on something that
-the project's developers might not want to pull into the repository.
-
-
-## Pull requests
-
-Good pull requests - patches, improvements, new features - are a fantastic
-help. They should remain focused in scope and avoid containing unrelated
-commits.
-
-Make sure to adhere to the coding conventions used throughout a project
-(indentation, accurate comments, etc.) and any other requirements (such as test
-coverage).
-
-Please follow this process; it's the best way to get your work included in the
-project:
-
-1. [Fork](http://help.github.com/fork-a-repo/) the project, clone your fork,
-   and configure the remotes:
-
-   ```bash
-   # Clones your fork of the repo into the current directory in terminal
-   git clone https://github.com/<your-username>/<repo-name>.git
-   # Navigate to the newly cloned directory
-   cd <repo-name>
-   # Assigns the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/<upsteam-owner>/<repo-name>.git
-   ```
-
-2. If you cloned a while ago, get the latest changes from upstream:
-
-   ```bash
-   git checkout <dev-branch>
-   git pull upstream <dev-branch>
-   ```
-
-3. Create a new topic branch to contain your feature, change, or fix:
-
-   ```bash
-   git checkout -b <topic-branch-name>
-   ```
-
-4. Commit your changes in logical chunks. Please adhere to these [git commit
-   message
-   guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html)
-   or your pull request is unlikely be merged into the main project. Use git's
-   [interactive rebase](https://help.github.com/articles/interactive-rebase)
-   feature to tidy up your commits before making them public.
-
-5. Locally merge (or rebase) the upstream development branch into your topic branch:
-
-   ```bash
-   git pull [--rebase] upstream <dev-branch>
-   ```
-
-6. Push your topic branch up to your fork:
-
-   ```bash
-   git push origin <topic-branch-name>
-   ```
-
-10. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
-    with a clear title and description.
+* [Reporting bugs](CONTRIBUTING.md#reporting-bugs)
+* [Requesting features](CONTRIBUTING.md#requesting-features)
+* [Submitting pull requests](CONTRIBUTING.md#submitting-pull-requests)


### PR DESCRIPTION
Extract the information on contributing from the README to a dedicated
new root file CONTRIBUTING. This is both ensuring the README remains
concise and also allows to take advantage of GitHub's usability feature
that prompts people to read a repo's guidelines before reporting issues
or opening pull requests.

---

@necolas - I've taken the liberty to semantically apply the changes of your respective commit [Add a `CONTRIBUTING.md` file](https://github.com/h5bp/html5-boilerplate/commit/2c079ae144cbab66d21edc99dded693a910d9fc2#CONTRIBUTING.md) here as well to encourage/spread the use of this smart and helpful GitHub usability feature:

> Move the information on contributing from the bundled documentation to a
> new root file - CONTRIBUTING. This is both a more meaningful location
> (not part of code documentation) and allows us to take advantage of
> GitHub's latest UI changes that prompt people to read a repo's
> guidelines before reporting issues or opening pull requests.

This suggested/required minor changes to the header naming/structure to allow for cross linking from the now more concise README.

In particular, I've unified all headers to verb rather than noun style, which is definitely a matter of preference (I personally prefer nouns actually, but usability seems to suggest direct engagement to be more appropriate).

Likewise I've dropped the headings _Rules of Engagement_ and _Do not..._ in favor of _Contributing to this project_ and _Using the issue tracker_ to both better match the respective GitHub UI for [Contributing Guidelines](https://github.com/blog/1184-contributing-guidelines) and also be a bit less formal/commanding at first sight (the actual bullet points remain the same though), which hopefully encourages readers to ingest the respective explanations more open and thoroughly.
